### PR TITLE
docs(readme): affected example commands typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,8 +502,8 @@ Instead of passing the two SHAs, you can also pass the list of files, like this:
 
 ```bash
 npm run affected:apps -- --files="libs/mylib/index.ts,libs/mylib2/index.ts"
-npm run affected:builds ----files="libs/mylib/index.ts,libs/mylib2/index.ts"
-npm run affected:e2e ----files="libs/mylib/index.ts,libs/mylib2/index.ts"
+npm run affected:builds -- --files="libs/mylib/index.ts,libs/mylib2/index.ts"
+npm run affected:e2e -- --files="libs/mylib/index.ts,libs/mylib2/index.ts"
 npm run format:write -- --files="libs/mylib/index.ts,libs/mylib2/index.ts"
 npm run format:check -- --files="libs/mylib/index.ts,libs/mylib2/index.ts"
 ```


### PR DESCRIPTION
The commands should use `-- --files=` instead of `----files=`