### PR TITLE
Add multiple commands to show repro

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -114,10 +114,13 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              {
-                "command": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/deploy --siteName nrwl-nx-examples-products --outputPath dist/apps/products"
-              }
-            ]
+              "mkdir -p scripts",
+              "touch scripts/{args.name}.sh",
+              "chmod +x scripts/{args.name}.sh",
+              "(cp ./README.md scripts) && echo args getting passed: ",
+              "cp ./nx.json scripts"
+            ],
+            "parallel": false
           }
         }
       }


### PR DESCRIPTION
**Problem:**
* Raw arguments get appended to each command that does not explicitly use an argument 

**Repro Command:**
* Run: `nx run products:deploy --args='--name=testing'`

**What you'll see:**
* The first commands are taken straight from the NX documentation [here](https://nx.dev/angular/plugins/workspace/builders/run-commands#properties).
    * **Note:** `mkdir -p scripts` works fine since running `mkdir -p scripts --name=testing` does no harm
* The problem arises when you have commands like `cp` in which case appending `--name=testing` will break the command