### PR TITLE
bug(jest): comonents with svg templates cause error

### DIFF
--- a/apps/products/src/app/app.module.ts
+++ b/apps/products/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-
 import { StoreModule } from '@ngrx/store';
 import { AppComponent } from './app.component';
 

--- a/libs/products/home-page/src/lib/home-page/home-page.component.html
+++ b/libs/products/home-page/src/lib/home-page/home-page.component.html
@@ -13,3 +13,5 @@
     </a>
   </li>
 </ul>
+
+<products-svg></products-svg>

--- a/libs/products/home-page/src/lib/home-page/home-page.component.spec.ts
+++ b/libs/products/home-page/src/lib/home-page/home-page.component.spec.ts
@@ -1,11 +1,8 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { StoreModule } from '@ngrx/store';
-
 import { SharedProductStateModule } from '@nx-example/shared/product/state';
-
+import { SvgComponent } from '../svg-component/svg.component';
 import { HomePageComponent } from './home-page.component';
 
 describe('HomePageComponent', () => {
@@ -17,10 +14,9 @@ describe('HomePageComponent', () => {
       imports: [
         StoreModule.forRoot({}),
         RouterTestingModule,
-        SharedProductStateModule
+        SharedProductStateModule,
       ],
-      declarations: [HomePageComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+      declarations: [HomePageComponent, SvgComponent],
     }).compileComponents();
   }));
 

--- a/libs/products/home-page/src/lib/products-home-page.module.ts
+++ b/libs/products/home-page/src/lib/products-home-page.module.ts
@@ -1,10 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-
 import { SharedProductStateModule } from '@nx-example/shared/product/state';
-
 import { HomePageComponent } from './home-page/home-page.component';
+import { SvgComponent } from './svg-component/svg.component';
 
 @NgModule({
   imports: [
@@ -15,11 +14,11 @@ import { HomePageComponent } from './home-page/home-page.component';
       {
         path: '',
         pathMatch: 'full',
-        component: HomePageComponent
-      }
-    ])
+        component: HomePageComponent,
+      },
+    ]),
   ],
-  declarations: [HomePageComponent],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  declarations: [HomePageComponent, SvgComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ProductsHomePageModule {}

--- a/libs/products/home-page/src/lib/svg-component/svg.component.svg
+++ b/libs/products/home-page/src/lib/svg-component/svg.component.svg
@@ -1,0 +1,4 @@
+<svg height="100" width="100">
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+  Sorry, your browser does not support inline SVG.
+</svg>

--- a/libs/products/home-page/src/lib/svg-component/svg.component.ts
+++ b/libs/products/home-page/src/lib/svg-component/svg.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'products-svg',
+  templateUrl: './svg.component.svg',
+  styleUrls: ['./svg.component.scss'],
+})
+export class SvgComponent {}


### PR DESCRIPTION
## Repro

- Clone nx-examples
- Create Component having SVG Tempalte
- Use component in `HomePageComponent`
- Reference SVG-Component in `home-page.component.spec.ts`
- Execute `nx test --project products-home-page`

> Test failes

```
 FAIL   products-home-page  libs/products/home-page/src/lib/products-home-page.module.spec.ts
  ● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/gregor/workbench/scratch/angular/nx-examples/libs/products/home-page/src/lib/svg-component/svg.component.svg:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){<svg height="100" width="100">
                                                                                             ^

    SyntaxError: Unexpected token '<'

      3 | @Component({
      4 |   selector: 'products-svg',
    > 5 |   templateUrl: './svg.component.svg',
        |   ^
      6 |   styleUrls: ['./svg.component.scss'],
      7 | })
      8 | export class SvgComponent {}

      at Runtime.createScriptFromCode (../../../node_modules/jest-runtime/build/index.js:1270:14)
      at Object.<anonymous> (src/lib/svg-component/svg.component.ts:5:3)
```