### PR TITLE
bug(tslint): missing projectGraph break tslint

### DIFF
--- a/apps/cart/tslint.json
+++ b/apps/cart/tslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "directive-selector": [true, "attribute", "demo", "camelCase"],
+    "component-selector": [true, "element", "demo", "kebab-case"]
+  },
+  "linterOptions": {
+    "exclude": ["!**/*"]
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,24 @@
+{
+  "rulesDirectory": [
+    "node_modules/@nrwl/workspace/src/tslint",
+    "node_modules/codelyzer"
+  ],
+  "linterOptions": {
+    "exclude": ["**/*"]
+  },
+  "rules": {
+    "nx-enforce-module-boundaries": [
+      true,
+      {
+        "enforceBuildableLibDependency": true,
+        "allow": [],
+        "depConstraints": [
+          {
+            "sourceTag": "*",
+            "onlyDependOnLibsWithTags": ["*"]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Reproduced bug for nrwl/nx#5399 tslint issue

Steps to reproduce,

```
rm -rf node_modules/.cache
npx tslint -p tsconfig.base.json
```
after running nx lint its working fine
```
nx lint
npx tslint -p tsconfig.base.json
```