### PR TITLE
fix: corrects spelling of example cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Run `nx affected:test` to execute the unit tests affected by a change.
 
 ## Running end-to-end tests
 
-Run `ng e2e my-app` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
+Run `nx e2e my-app` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
 
 Run `nx affected:e2e` to execute the end-to-end tests affected by a change.
 


### PR DESCRIPTION
This PR potentially corrects a misspelling I noticed while getting started with nx. 

Oops! If `ng` is correct