### PR TITLE
Setting workspace.json causes Nx to look at project.json

### DIFF
--- a/apps/sample-app/package.json
+++ b/apps/sample-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample-app",
+  "description": "This is a sample application made to help reproduce an issue",
+  "scripts": {
+    "start": "echo \"The start script ran successfully!\""
+  }
+}

--- a/workspace.json
+++ b/workspace.json
@@ -8,6 +8,7 @@
     "products-e2e": "apps/products-e2e",
     "products-home-page": "libs/products/home-page",
     "products-product-detail-page": "libs/products/product-detail-page",
+    "sample-app": "apps/sample-app",
     "shared-assets": "libs/shared/assets",
     "shared-cart-state": "libs/shared/cart/state",
     "shared-e2e-utils": "libs/shared/e2e-utils",


### PR DESCRIPTION
If you run `yarn nx r sample-app:start` when `workspace.json` doesn't exist, it prints out "The start script ran successfully!". If `workspace.json` does exist, it fails with the following error:

```shell
ENOENT: no such file or directory, open '/Users/my_username/nx-examples/apps/sample-app/project.json'
error Command failed with exit code 1.
```

This is a reproduction of [this issue](https://github.com/nrwl/nx/issues/8874).