### PR TITLE
Concurrent js:serve runExecutor iterators failure

### DIFF
--- a/apps/dummy/.eslintrc.json
+++ b/apps/dummy/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/dummy/README.md
+++ b/apps/dummy/README.md
@@ -1,0 +1,15 @@
+# dummy
+
+This application was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build dummy` to build the application.
+
+## Starting
+
+Run `nx start dummy` to start/run the application.
+
+## Running unit tests
+
+Run `nx test dummy` to execute the unit tests via [Jest](https://jestjs.io).

--- a/apps/dummy/jest.config.js
+++ b/apps/dummy/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'dummy',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/apps/dummy',
+};

--- a/apps/dummy/package.json
+++ b/apps/dummy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-example/dummy",
+  "version": "0.0.1",
+  "type": "commonjs"
+}

--- a/apps/dummy/project.json
+++ b/apps/dummy/project.json
@@ -1,0 +1,39 @@
+{
+  "root": "apps/dummy",
+  "sourceRoot": "apps/dummy/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/dummy",
+        "main": "apps/dummy/src/index.ts",
+        "tsConfig": "apps/dummy/tsconfig.app.json",
+        "assets": ["apps/dummy/*.md"]
+      }
+    },
+    "serve": {
+      "executor": "@nrwl/js:node",
+      "options": {
+        "buildTarget": "dummy:build"
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["apps/dummy/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/apps/dummy"],
+      "options": {
+        "jestConfig": "apps/dummy/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/dummy/src/app/dummy.ts
+++ b/apps/dummy/src/app/dummy.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-eval
+const argv = eval('process').argv as string[];
+export function dummy() {
+  setInterval(() => {
+    console.log(argv.slice(2));
+  }, 1000);
+}

--- a/apps/dummy/src/index.ts
+++ b/apps/dummy/src/index.ts
@@ -1,0 +1,2 @@
+import { dummy } from './app/dummy';
+dummy();

--- a/apps/dummy/tsconfig.app.json
+++ b/apps/dummy/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/apps/dummy/tsconfig.json
+++ b/apps/dummy/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/dummy/tsconfig.spec.json
+++ b/apps/dummy/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/foo/.babelrc
+++ b/libs/foo/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/foo/.eslintrc.json
+++ b/libs/foo/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/foo/README.md
+++ b/libs/foo/README.md
@@ -1,0 +1,7 @@
+# foo
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test foo` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/foo/jest.config.js
+++ b/libs/foo/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'foo',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/foo',
+};

--- a/libs/foo/project.json
+++ b/libs/foo/project.json
@@ -1,0 +1,13 @@
+{
+  "root": "libs/foo",
+  "sourceRoot": "libs/foo/src",
+  "projectType": "library",
+  "targets": {
+    "baz": {
+      "executor": "./libs/foo/src/executors:bar",
+      "outputs": ["{options.outputFile}"],
+      "options": {}
+    }
+  },
+  "tags": []
+}

--- a/libs/foo/src/executors/bar/combine.js
+++ b/libs/foo/src/executors/bar/combine.js
@@ -1,0 +1,32 @@
+module.exports = async function* combine(iterable) {
+  const asyncIterators = Array.from(iterable, (o) => o[Symbol.asyncIterator]());
+  const results = [];
+  let count = asyncIterators.length;
+  const never = new Promise(() => {});
+  function getNext(asyncIterator, index) {
+    return asyncIterator.next().then((result) => ({
+      index,
+      result,
+    }));
+  }
+  const nextPromises = asyncIterators.map(getNext);
+  try {
+    while (count) {
+      const { index, result } = await Promise.race(nextPromises);
+      if (result.done) {
+        nextPromises[index] = never;
+        results[index] = result.value;
+        count--;
+      } else {
+        nextPromises[index] = getNext(asyncIterators[index], index);
+        yield result.value;
+      }
+    }
+  } finally {
+    for (const [index, iterator] of asyncIterators.entries())
+      if (nextPromises[index] != never && iterator.return != null)
+        iterator.return();
+    // no await here - see https://github.com/tc39/proposal-async-iteration/issues/126
+  }
+  return results;
+};

--- a/libs/foo/src/executors/bar/impl.js
+++ b/libs/foo/src/executors/bar/impl.js
@@ -1,0 +1,42 @@
+const { runExecutor } = require('@nrwl/devkit');
+const combine = require('./combine');
+
+module.exports = {
+  /**
+   * This is executor is what does not work.
+   * I cannot run two `runExecutor`s at the same time
+   * using the js:serve executor.
+   *
+   * Observe that APP_1 never emits anything. This is
+   * incorrect behavior.
+   *
+   * Try:
+   * - changing the target to `build` - works!
+   *
+   *
+   */
+  default: async function* fooExecutor(_options, ctx) {
+    const asyncIterators = await Promise.all([
+      runExecutor(
+        {
+          target: 'serve',
+          project: 'dummy',
+        },
+        { args: 'APP_1' },
+        ctx
+      ),
+      runExecutor(
+        {
+          target: 'serve',
+          project: 'dummy',
+        },
+        { args: 'APP_2' },
+        ctx
+      ),
+    ]);
+    for await (const evt of combine(asyncIterators)) {
+      yield evt;
+    }
+    return { success: true };
+  },
+};

--- a/libs/foo/src/executors/bar/schema.json
+++ b/libs/foo/src/executors/bar/schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "cli": "nx",
+  "properties": {}
+}

--- a/libs/foo/src/executors/executor.json
+++ b/libs/foo/src/executors/executor.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "bar": {
+      "implementation": "./bar/impl",
+      "schema": "./bar/schema.json",
+      "description": ""
+    }
+  }
+}

--- a/libs/foo/src/executors/package.json
+++ b/libs/foo/src/executors/package.json
@@ -1,0 +1,3 @@
+{
+  "executors": "./executor.json"
+}

--- a/libs/foo/tsconfig.json
+++ b/libs/foo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/libs/foo/tsconfig.lib.json
+++ b/libs/foo/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/libs/foo/tsconfig.spec.json
+++ b/libs/foo/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@nrwl/workspace": "13.8.1",
     "@testing-library/react": "11.2.6",
     "@types/jest": "27.0.2",
-    "@types/node": "14.14.33",
+    "@types/node": "17.0.21",
     "@types/react": "17.0.3",
     "@types/react-dom": "17.0.3",
     "@types/react-router-dom": "5.1.7",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
     "baseUrl": ".",
     "paths": {
       "@nx-example/cart/cart-page": ["libs/cart/cart-page/src/index.ts"],
+      "@nx-example/foo": ["libs/foo/src/index.ts"],
       "@nx-example/products/home-page": [
         "libs/products/home-page/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,8 @@
     "cart": "apps/cart",
     "cart-cart-page": "libs/cart/cart-page",
     "cart-e2e": "apps/cart-e2e",
+    "dummy": "apps/dummy",
+    "foo": "libs/foo",
     "products": "apps/products",
     "products-e2e": "apps/products-e2e",
     "products-home-page": "libs/products/home-page",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,10 +3804,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
   integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
-"@types/node@14.14.33":
-  version "14.14.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
-  integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
+"@types/node@17.0.21":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
 "@types/node@^14.14.31":
   version "14.17.14"


### PR DESCRIPTION
# Problem

- executor `foo` tries to run and iterate through two `js:serve` executors on the `dummy` app, but only one app runs

# Understanding the demo

- `runExecutor` is called twice, producing two async iterators
- those iterators are combined, then all events attempted to be iterated through

...however, execution _halts_ for one iterator.

You can swap the target (such as `build`, `lint`) and these targets **do not** suffer the failure