### PR TITLE
@types/react-router-dom bug when compiling executor

### DIFF
--- a/tools/executors/echo/executor.json
+++ b/tools/executors/echo/executor.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "echo": {
+      "implementation": "./impl",
+      "schema": "./schema.json",
+      "description": "Runs `echo` (to test executors out)."
+    }
+  }
+}

--- a/tools/executors/echo/impl.js
+++ b/tools/executors/echo/impl.js
@@ -1,0 +1,60 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+exports.__esModule = true;
+var child_process_1 = require("child_process");
+var util_1 = require("util");
+function echoExecutor(options, context) {
+    return __awaiter(this, void 0, void 0, function () {
+        var _a, stdout, stderr, success;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    console.info("Executing \"echo\"...");
+                    console.info("Options: ".concat(JSON.stringify(options, null, 2)));
+                    return [4 /*yield*/, (0, util_1.promisify)(child_process_1.exec)("echo ".concat(options.textToEcho))];
+                case 1:
+                    _a = _b.sent(), stdout = _a.stdout, stderr = _a.stderr;
+                    console.log(stdout);
+                    console.error(stderr);
+                    success = !stderr;
+                    return [2 /*return*/, { success: success }];
+            }
+        });
+    });
+}
+exports["default"] = echoExecutor;

--- a/tools/executors/echo/impl.ts
+++ b/tools/executors/echo/impl.ts
@@ -1,0 +1,24 @@
+import type { ExecutorContext } from '@nrwl/devkit';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+export interface EchoExecutorOptions {
+  textToEcho: string;
+}
+
+export default async function echoExecutor(
+  options: EchoExecutorOptions,
+  context: ExecutorContext
+): Promise<{ success: boolean }> {
+  console.info(`Executing "echo"...`);
+  console.info(`Options: ${JSON.stringify(options, null, 2)}`);
+
+  const { stdout, stderr } = await promisify(exec)(
+    `echo ${options.textToEcho}`
+  );
+  console.log(stdout);
+  console.error(stderr);
+
+  const success = !stderr;
+  return { success };
+}

--- a/tools/executors/echo/package.json
+++ b/tools/executors/echo/package.json
@@ -1,0 +1,3 @@
+{
+  "executors": "./executor.json"
+}

--- a/tools/executors/echo/schema.json
+++ b/tools/executors/echo/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "textToEcho": {
+      "type": "string",
+      "description": "Text To Echo"
+    }
+  }
+}


### PR DESCRIPTION
Running `npx tsc tools/executors/echo/impl` will cause the following error:

```
node_modules/@types/react-router-dom/index.d.ts:13:10 - error TS2305: Module '"react-router"' has no exported member 'match'.

13 import { match } from 'react-router';
```