### PR TITLE
Issue with TypeScript declaration files

### DIFF
--- a/libs/lib-1/.babelrc
+++ b/libs/lib-1/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/web/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/libs/lib-1/.eslintrc.json
+++ b/libs/lib-1/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/lib-1/README.md
+++ b/libs/lib-1/README.md
@@ -1,0 +1,11 @@
+# lib-1
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build lib-1` to build the library.
+
+## Running unit tests
+
+Run `nx test lib-1` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/lib-1/jest.config.ts
+++ b/libs/lib-1/jest.config.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export default {
+  displayName: 'lib-1',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/lib-1',
+};

--- a/libs/lib-1/package.json
+++ b/libs/lib-1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-example/lib-1",
+  "version": "0.0.1",
+  "type": "commonjs"
+}

--- a/libs/lib-1/project.json
+++ b/libs/lib-1/project.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/lib-1/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/lib-1",
+        "main": "libs/lib-1/src/index.ts",
+        "tsConfig": "libs/lib-1/tsconfig.lib.json",
+        "assets": ["libs/lib-1/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/lib-1/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/lib-1"],
+      "options": {
+        "jestConfig": "libs/lib-1/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/lib-1/src/index.ts
+++ b/libs/lib-1/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/lib-1';

--- a/libs/lib-1/src/lib/lib-1.spec.ts
+++ b/libs/lib-1/src/lib/lib-1.spec.ts
@@ -1,0 +1,7 @@
+import { lib1 } from './lib-1';
+
+describe('lib1', () => {
+  it('should work', () => {
+    expect(lib1()).toEqual('lib-1');
+  });
+});

--- a/libs/lib-1/src/lib/lib-1.ts
+++ b/libs/lib-1/src/lib/lib-1.ts
@@ -1,0 +1,3 @@
+export function lib1(): string {
+  return 'lib-1';
+}

--- a/libs/lib-1/src/lib/lib-1.ts
+++ b/libs/lib-1/src/lib/lib-1.ts
@@ -1,3 +1,1 @@
-export function lib1(): string {
-  return 'lib-1';
-}
+export type TestFunction = (arg: string) => string;

--- a/libs/lib-1/tsconfig.json
+++ b/libs/lib-1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/lib-1/tsconfig.lib.json
+++ b/libs/lib-1/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/lib-1/tsconfig.spec.json
+++ b/libs/lib-1/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/lib-2/.babelrc
+++ b/libs/lib-2/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/web/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/libs/lib-2/.eslintrc.json
+++ b/libs/lib-2/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/lib-2/README.md
+++ b/libs/lib-2/README.md
@@ -1,0 +1,11 @@
+# lib-2
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build lib-2` to build the library.
+
+## Running unit tests
+
+Run `nx test lib-2` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/lib-2/jest.config.ts
+++ b/libs/lib-2/jest.config.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export default {
+  displayName: 'lib-2',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/lib-2',
+};

--- a/libs/lib-2/package.json
+++ b/libs/lib-2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-example/lib-2",
+  "version": "0.0.1",
+  "type": "commonjs"
+}

--- a/libs/lib-2/project.json
+++ b/libs/lib-2/project.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/lib-2/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/lib-2",
+        "main": "libs/lib-2/src/index.ts",
+        "tsConfig": "libs/lib-2/tsconfig.lib.json",
+        "assets": ["libs/lib-2/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/lib-2/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/lib-2"],
+      "options": {
+        "jestConfig": "libs/lib-2/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/lib-2/src/index.ts
+++ b/libs/lib-2/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/lib-2';

--- a/libs/lib-2/src/index.ts
+++ b/libs/lib-2/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/lib-2';
+export * from './lib/test';

--- a/libs/lib-2/src/lib/lib-2.spec.ts
+++ b/libs/lib-2/src/lib/lib-2.spec.ts
@@ -1,0 +1,7 @@
+import { lib2 } from './lib-2';
+
+describe('lib2', () => {
+  it('should work', () => {
+    expect(lib2()).toEqual('lib-2');
+  });
+});

--- a/libs/lib-2/src/lib/lib-2.ts
+++ b/libs/lib-2/src/lib/lib-2.ts
@@ -1,0 +1,3 @@
+export function lib2(): string {
+  return 'lib-2';
+}

--- a/libs/lib-2/src/lib/lib-2.ts
+++ b/libs/lib-2/src/lib/lib-2.ts
@@ -1,3 +1,3 @@
-export function lib2(): string {
-  return 'lib-2';
-}
+import { TestFunction } from '@nx-example/lib-1';
+
+export const testFunction: TestFunction = (arg: string) => arg;

--- a/libs/lib-2/src/lib/test.ts
+++ b/libs/lib-2/src/lib/test.ts
@@ -1,0 +1,3 @@
+import { testFunction } from './lib-2';
+
+export const test = testFunction;

--- a/libs/lib-2/tsconfig.json
+++ b/libs/lib-2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/lib-2/tsconfig.lib.json
+++ b/libs/lib-2/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/lib-2/tsconfig.spec.json
+++ b/libs/lib-2/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@nrwl/devkit": "14.2.0-rc.1",
     "@nrwl/eslint-plugin-nx": "14.2.0-rc.1",
     "@nrwl/jest": "14.2.0-rc.1",
+    "@nrwl/js": "14.2.0-rc.1",
     "@nrwl/linter": "14.2.0-rc.1",
     "@nrwl/nx-cloud": "14.0.5",
     "@nrwl/react": "14.2.0-rc.1",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,8 @@
     "baseUrl": ".",
     "paths": {
       "@nx-example/cart/cart-page": ["libs/cart/cart-page/src/index.ts"],
+      "@nx-example/lib-1": ["libs/lib-1/src/index.ts"],
+      "@nx-example/lib-2": ["libs/lib-2/src/index.ts"],
       "@nx-example/products/home-page": [
         "libs/products/home-page/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,8 @@
     "cart": "apps/cart",
     "cart-cart-page": "libs/cart/cart-page",
     "cart-e2e": "apps/cart-e2e",
+    "lib-1": "libs/lib-1",
+    "lib-2": "libs/lib-2",
     "products": "apps/products",
     "products-e2e": "apps/products-e2e",
     "products-home-page": "libs/products/home-page",


### PR DESCRIPTION
This PR demonstrates an issue with the TypeScript declaration files produced by `tsc`.

Steps to reproduce:

1. Run `nx build lib-2`.
2. Open `dist/libs/lib-2/src/lib/test.d.ts`.
3. Observe the broken import from `dist`.

Example of `test.d.ts`:

```ts
export declare const test: import("../../../../dist/libs/lib-1/src").TestFunction;
```


