### PR TITLE
Jest tests should run as expected with coverage report options set

### DIFF
--- a/apps/cart/project.json
+++ b/apps/cart/project.json
@@ -94,7 +94,8 @@
       "executor": "@nrwl/jest:jest",
       "options": {
         "jestConfig": "apps/cart/jest.config.ts",
-        "passWithNoTests": true
+        "passWithNoTests": true,
+        "coverageReporters": [["text", { "skipFull": true }]]
       },
       "outputs": ["coverage/apps/cart"]
     },


### PR DESCRIPTION
This is a simple reproduction steps to https://github.com/nrwl/nx/issues/11090

`yarn nx test cart`