### PR TITLE
import breaks enforce-module-boundaries linting completely

### DIFF
--- a/libs/products/home-page/src/lib/home-page/home-page.component.ts
+++ b/libs/products/home-page/src/lib/home-page/home-page.component.ts
@@ -3,6 +3,8 @@ import { Component } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
+import * as ProductStateActions from 'libs/shared/product/state/src/lib/+state/products.actions';
+
 import {
   getProducts,
   getProductsState,
@@ -23,4 +25,6 @@ export class HomePageComponent {
   );
 
   constructor(private store: Store<ProductsPartialState>) {}
+
+  action: ProductStateActions.ProductsAction;
 }


### PR DESCRIPTION
PR with reproduction code for an import that breaks the enforce-module-boundaries linting rule.

```
Linting "products-home-page"...

 >  NX   Cannot read properties of undefined (reading 'name')

   Occurred while linting ~/nx-examples/libs/products/home-page/src/lib/home-page/home-page.component.ts:6
   Rule: "@nrwl/nx/enforce-module-boundaries"
   Pass --verbose to see the stacktrace.
```