### PR TITLE
fix(): update links to external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This project was generated using [Nx](https://nx.dev).
 
 [30-minute video showing all Nx features](https://nx.dev/getting-started/why-nx)
 
-[Interactive Tutorial](https://nx.dev/tutorial/01-create-application)
-
 ## Adding capabilities to your workspace
 
 Nx supports many plugins which add capabilities for developing different types of applications and different tools.


### PR DESCRIPTION
## Description
* Switch to the new URL
* Remove NO existing tutorial anymore

## How to review?
* Check that
  * https://nx.dev/getting-started/what-is-nx
    * NOT existing anymore
    *  https://nx.dev/getting-started/why-nx is the current alternative
  *  https://nx.dev/tutorial/01-create-application does NOT exist anymore