### PR TITLE
fix: updated links to point to updated doc locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run `nx dep-graph` to see a diagram of the dependencies of your projects.
 
 ## Further help
 
-Visit the [Nx Documentation](https://nx.dev) to learn more.
+Visit the [Nx Documentation](https://nx.dev/getting-started/intro) to learn more.
 
 ## ☁ Nx Cloud
 
@@ -99,4 +99,4 @@ Teams using Nx gain the advantage of building full-stack applications with their
 
 [Computation Caching Fundamentals](https://blog.nrwl.io/computation-caching-the-fundamentals-behind-nxs-lightning-fast-execution-dc761fe41eb8)
 
-[Computation Caching with NX](https://nx.dev/latest/core-concepts/computation-caching)
+[Computation Caching with NX](https://nx.dev/concepts/mental-model#computation-hashing-and-caching)


### PR DESCRIPTION
## Overview
I noted that the last link (computation caching with Nx) went to a 404 page so I updated it to the new location under the "Mental Model". I also pointed the "Nx Documentation" link directly to the latest docs main page, but that's more of a personal preference.

## Type of Change
- [ ] Documentation update (changes to documentation)
- [X] Broken links (due to moved/modified pages)

## Details
Updated `README.md` to include the following pages:
- https://nx.dev/getting-started/intro
- https://nx.dev/concepts/mental-model#computation-hashing-and-caching