### PR TITLE
chore(repo): migrate to TypeScript solution-style configs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 node_modules
+out-tsc
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # compiled output
 /dist
 /tmp
-/out-tsc
+out-tsc
 
 # dependencies
 /node_modules

--- a/apps/cart-e2e/.eslintrc.json
+++ b/apps/cart-e2e/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:cypress/recommended", "../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/apps/cart-e2e/package.json
+++ b/apps/cart-e2e/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@nx-example/cart-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@nx-example/shared-e2e-utils": "workspace:*"
+  }
+}

--- a/apps/cart-e2e/src/e2e/app.cy.ts
+++ b/apps/cart-e2e/src/e2e/app.cy.ts
@@ -1,4 +1,4 @@
-import { getHeader } from '@nx-example/shared/e2e-utils';
+import { getHeader } from '@nx-example/shared-e2e-utils';
 
 import { getPage } from '../support/app.po';
 

--- a/apps/cart-e2e/tsconfig.json
+++ b/apps/cart-e2e/tsconfig.json
@@ -2,10 +2,16 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "sourceMap": false,
-    "outDir": "../../dist/out-tsc",
+    "outDir": "out-tsc/e2e",
     "allowJs": true,
-    "rootDir": "../..",
+    "typeRoots": ["../../node_modules/@types", "../../node_modules"],
     "types": ["cypress", "node"]
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
+  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"],
+  "exclude": ["out-tsc"],
+  "references": [
+    {
+      "path": "../../libs/shared/e2e-utils"
+    }
+  ]
 }

--- a/apps/cart/.eslintrc.json
+++ b/apps/cart/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/apps/cart/jest.config.ts
+++ b/apps/cart/jest.config.ts
@@ -1,7 +1,15 @@
 /* eslint-disable */
 module.exports = {
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          transform: { react: { runtime: 'automatic' } },
+        },
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   coverageDirectory: '../../coverage/apps/cart',

--- a/apps/cart/package.json
+++ b/apps/cart/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nx-example/cart",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@nx-example/cart-cart-page": "workspace:*",
+    "@nx-example/shared-assets": "workspace:*",
+    "@nx-example/shared-header": "workspace:*",
+    "@nx-example/shared-styles": "workspace:*"
+  }
+}

--- a/apps/cart/src/app/app.tsx
+++ b/apps/cart/src/app/app.tsx
@@ -1,8 +1,8 @@
 import { Route, Routes } from 'react-router-dom';
 
-import '@nx-example/shared/header';
+import '@nx-example/shared-header';
 
-import { CartCartPage } from '@nx-example/cart/cart-page';
+import { CartCartPage } from '@nx-example/cart-cart-page';
 
 export const App = () => {
   return (

--- a/apps/cart/tsconfig.app.json
+++ b/apps/cart/tsconfig.app.json
@@ -1,11 +1,13 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "types": [
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
-    ]
+    "outDir": "out-tsc/app",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "exclude": [
     "**/*.spec.ts",
@@ -15,9 +17,17 @@
     "jest.config.ts",
     "src/test-setup.ts"
   ],
-  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
   "files": [
     "../../node_modules/@nx/react/typings/cssmodule.d.ts",
     "../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../libs/shared/header/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cart/cart-page/tsconfig.lib.json"
+    }
   ]
 }

--- a/apps/cart/tsconfig.json
+++ b/apps/cart/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/apps/cart/tsconfig.spec.json
+++ b/apps/cart/tsconfig.spec.json
@@ -1,13 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
+    "outDir": "out-tsc/spec",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "types": [
       "jest",
-      "node",
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "node"
     ]
   },
   "include": [
@@ -25,5 +26,13 @@
   "files": [
     "../../node_modules/@nx/react/typings/cssmodule.d.ts",
     "../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "out-tsc"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
   ]
 }

--- a/apps/products-e2e/.eslintrc.json
+++ b/apps/products-e2e/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:cypress/recommended", "../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/apps/products-e2e/package.json
+++ b/apps/products-e2e/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@nx-example/products-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@nx-example/shared-e2e-utils": "workspace:*"
+  }
+}

--- a/apps/products-e2e/src/e2e/app.cy.ts
+++ b/apps/products-e2e/src/e2e/app.cy.ts
@@ -1,4 +1,4 @@
-import { getHeader } from '@nx-example/shared/e2e-utils';
+import { getHeader } from '@nx-example/shared-e2e-utils';
 
 import { getPage } from '../support/app.po';
 

--- a/apps/products-e2e/tsconfig.json
+++ b/apps/products-e2e/tsconfig.json
@@ -2,10 +2,16 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "sourceMap": false,
-    "outDir": "../../dist/out-tsc",
+    "outDir": "out-tsc/e2e",
     "allowJs": true,
-    "rootDir": "../..",
+    "typeRoots": ["../../node_modules/@types", "../../node_modules"],
     "types": ["cypress", "node"]
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
+  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"],
+  "exclude": ["out-tsc"],
+  "references": [
+    {
+      "path": "../../libs/shared/e2e-utils"
+    }
+  ]
 }

--- a/apps/products/.eslintrc.json
+++ b/apps/products/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/apps/products/package.json
+++ b/apps/products/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nx-example/products",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@nx-example/products-home-page": "workspace:*",
+    "@nx-example/products-product-detail-page": "workspace:*",
+    "@nx-example/shared-assets": "workspace:*",
+    "@nx-example/shared-header": "workspace:*",
+    "@nx-example/shared-styles": "workspace:*"
+  }
+}

--- a/apps/products/project.json
+++ b/apps/products/project.json
@@ -13,13 +13,15 @@
   },
   "targets": {
     "build": {
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@nx/angular:application",
       "options": {
-        "aot": true,
-        "outputPath": "dist/apps/products",
+        "outputPath": {
+          "base": "dist/apps/products",
+          "browser": ""
+        },
         "index": "apps/products/src/index.html",
-        "main": "apps/products/src/main.ts",
-        "polyfills": "apps/products/src/polyfills.ts",
+        "browser": "apps/products/src/main.ts",
+        "polyfills": ["apps/products/src/polyfills.ts"],
         "tsConfig": "apps/products/tsconfig.app.json",
         "assets": [
           "apps/products/src/_redirects",
@@ -52,11 +54,7 @@
           "optimization": true,
           "outputHashing": "all",
           "sourceMap": false,
-          "namedChunks": false,
-          "aot": true,
           "extractLicenses": true,
-          "vendorChunk": false,
-          "buildOptimizer": true,
           "budgets": [
             {
               "type": "initial",
@@ -73,7 +71,7 @@
       "outputs": ["{options.outputPath}"]
     },
     "serve": {
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@angular/build:dev-server",
       "options": {
         "buildTarget": "products:build"
       },
@@ -85,7 +83,7 @@
       "continuous": true
     },
     "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "executor": "@angular/build:extract-i18n",
       "options": {
         "buildTarget": "products:build"
       }

--- a/apps/products/src/app/app.component.ts
+++ b/apps/products/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import '@nx-example/shared/header';
+import '@nx-example/shared-header';
 
 @Component({
   selector: 'nx-example-root',

--- a/apps/products/src/app/app.module.ts
+++ b/apps/products/src/app/app.module.ts
@@ -15,14 +15,14 @@ import { AppComponent } from './app.component';
           path: '',
           pathMatch: 'full',
           loadChildren: () =>
-            import('@nx-example/products/home-page').then(
+            import('@nx-example/products-home-page').then(
               (module) => module.ProductsHomePageModule
             ),
         },
         {
           path: 'product',
           loadChildren: () =>
-            import('@nx-example/products/product-detail-page').then(
+            import('@nx-example/products-product-detail-page').then(
               (module) => module.ProductsProductDetailPageModule
             ),
         },

--- a/apps/products/tsconfig.app.json
+++ b/apps/products/tsconfig.app.json
@@ -1,17 +1,32 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "types": [],
+    "outDir": "out-tsc/app",
+    "rootDir": "src",
     "target": "ES2022",
     "useDefineForClassFields": false,
-    "moduleResolution": "bundler"
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"],
+    "types": []
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
-  "include": [
-    "**/*.d.ts",
-    "../../libs/products/home-page/src/index.ts",
-    "../../libs/products/product-detail-page/src/index.ts"
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "src/test-setup.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
   ],
-  "exclude": ["jest.config.ts"]
+  "references": [
+    {
+      "path": "../../libs/shared/header/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/products/product-detail-page/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/products/home-page/tsconfig.lib.json"
+    }
+  ]
 }

--- a/apps/products/tsconfig.editor.json
+++ b/apps/products/tsconfig.editor.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["**/*.ts"],
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "out-tsc/editor",
     "types": ["jest", "node"]
   },
-  "exclude": ["jest.config.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "out-tsc"],
+  "references": [{ "path": "./tsconfig.app.json" }]
 }

--- a/apps/products/tsconfig.json
+++ b/apps/products/tsconfig.json
@@ -1,23 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "lib": ["dom", "es2022"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    },
-    {
-      "path": "./tsconfig.editor.json"
-    }
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" },
+    { "path": "./tsconfig.editor.json" }
   ]
 }

--- a/apps/products/tsconfig.spec.json
+++ b/apps/products/tsconfig.spec.json
@@ -1,13 +1,31 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "out-tsc/spec",
     "module": "preserve",
-    "types": ["jest", "node"],
-    "target": "es2016",
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "target": "es2016",
+    "isolatedModules": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ],
+  "exclude": [
+    "out-tsc"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
 }

--- a/libs/cart/cart-page/.eslintrc.json
+++ b/libs/cart/cart-page/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/cart/cart-page/jest.config.ts
+++ b/libs/cart/cart-page/jest.config.ts
@@ -1,7 +1,15 @@
 /* eslint-disable */
 module.exports = {
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          transform: { react: { runtime: 'automatic' } },
+        },
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   coverageDirectory: '../../../coverage/libs/cart/cart-page',

--- a/libs/cart/cart-page/package.json
+++ b/libs/cart/cart-page/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nx-example/cart-cart-page",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-cart-state": "workspace:*",
+    "@nx-example/shared-product-state": "workspace:*",
+    "@nx-example/shared-product-ui": "workspace:*"
+  }
+}

--- a/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
+++ b/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
@@ -2,7 +2,7 @@ import { useReducer } from 'react';
 
 import styled from '@emotion/styled';
 
-import '@nx-example/shared/product/ui';
+import '@nx-example/shared-product-ui';
 
 import {
   CartItem,
@@ -10,12 +10,12 @@ import {
   getItemCost,
   getTotalCost,
   SetQuantity,
-} from '@nx-example/shared/cart/state/react';
+} from '@nx-example/shared-cart-state/react';
 import {
   getProduct,
   initialState,
   productsReducer,
-} from '@nx-example/shared/product/state/react';
+} from '@nx-example/shared-product-state/react';
 
 const StyledUl = styled.ul`
   display: flex;

--- a/libs/cart/cart-page/tsconfig.json
+++ b/libs/cart/cart-page/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/cart/cart-page/tsconfig.lib.json
+++ b/libs/cart/cart-page/tsconfig.lib.json
@@ -1,15 +1,35 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "types": []
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "exclude": [
     "**/*.spec.ts",
     "**/*.test.ts",
     "**/*.spec.tsx",
     "**/*.test.tsx",
-    "jest.config.ts"
+    "jest.config.ts",
+    "src/test-setup.ts"
   ],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "references": [
+    {
+      "path": "../../shared/product/ui/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/product/state/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/cart/state/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/cart/cart-page/tsconfig.spec.json
+++ b/libs/cart/cart-page/tsconfig.spec.json
@@ -1,10 +1,19 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "outDir": "out-tsc/spec",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "**/*.spec.ts",
     "**/*.test.ts",
@@ -16,5 +25,13 @@
     "**/*.test.jsx",
     "**/*.d.ts",
     "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
   ]
 }

--- a/libs/products/home-page/.eslintrc.json
+++ b/libs/products/home-page/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/products/home-page/package.json
+++ b/libs/products/home-page/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nx-example/products-home-page",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-product-state": "workspace:*",
+    "@nx-example/shared-product-types": "workspace:*",
+    "@nx-example/shared-product-ui": "workspace:*"
+  }
+}

--- a/libs/products/home-page/src/lib/home-page/home-page.component.spec.ts
+++ b/libs/products/home-page/src/lib/home-page/home-page.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { StoreModule } from '@ngrx/store';
 
-import { SharedProductStateModule } from '@nx-example/shared/product/state';
+import { SharedProductStateModule } from '@nx-example/shared-product-state';
 
 import { HomePageComponent } from './home-page.component';
 

--- a/libs/products/home-page/src/lib/home-page/home-page.component.ts
+++ b/libs/products/home-page/src/lib/home-page/home-page.component.ts
@@ -7,9 +7,9 @@ import {
   getProducts,
   getProductsState,
   ProductsPartialState,
-} from '@nx-example/shared/product/state';
-import { Product } from '@nx-example/shared/product/types';
-import '@nx-example/shared/product/ui';
+} from '@nx-example/shared-product-state';
+import { Product } from '@nx-example/shared-product-types';
+import '@nx-example/shared-product-ui';
 
 @Component({
   selector: 'products-home-page',

--- a/libs/products/home-page/src/lib/products-home-page.module.ts
+++ b/libs/products/home-page/src/lib/products-home-page.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { SharedProductStateModule } from '@nx-example/shared/product/state';
+import { SharedProductStateModule } from '@nx-example/shared-product-state';
 
 import { HomePageComponent } from './home-page/home-page.component';
 

--- a/libs/products/home-page/tsconfig.json
+++ b/libs/products/home-page/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "lib": ["dom", "es2022"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/products/home-page/tsconfig.lib.json
+++ b/libs/products/home-page/tsconfig.lib.json
@@ -1,12 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "target": "es2015",
-    "declaration": true,
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"],
     "inlineSources": true,
-    "types": [],
-    "lib": ["dom", "es2022"]
+    "types": []
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
@@ -22,5 +24,18 @@
     "**/*.test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../shared/product/ui/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/product/types/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/product/state/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/products/home-page/tsconfig.spec.json
+++ b/libs/products/home-page/tsconfig.spec.json
@@ -1,13 +1,31 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "outDir": "out-tsc/spec",
     "module": "preserve",
-    "types": ["jest", "node"],
-    "target": "es2016",
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "target": "es2016",
+    "isolatedModules": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
+  ]
 }

--- a/libs/products/product-detail-page/.eslintrc.json
+++ b/libs/products/product-detail-page/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/products/product-detail-page/package.json
+++ b/libs/products/product-detail-page/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@nx-example/products-product-detail-page",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-product-state": "workspace:*",
+    "@nx-example/shared-product-ui": "workspace:*"
+  }
+}

--- a/libs/products/product-detail-page/src/lib/product-detail-page/product-detail-page.component.spec.ts
+++ b/libs/products/product-detail-page/src/lib/product-detail-page/product-detail-page.component.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { of } from 'rxjs';
 
-import { SharedProductStateModule } from '@nx-example/shared/product/state';
+import { SharedProductStateModule } from '@nx-example/shared-product-state';
 
 import { ProductDetailPageComponent } from './product-detail-page.component';
 

--- a/libs/products/product-detail-page/src/lib/product-detail-page/product-detail-page.component.ts
+++ b/libs/products/product-detail-page/src/lib/product-detail-page/product-detail-page.component.ts
@@ -8,8 +8,8 @@ import {
   getProduct,
   getProductsState,
   ProductsPartialState,
-} from '@nx-example/shared/product/state';
-import '@nx-example/shared/product/ui';
+} from '@nx-example/shared-product-state';
+import '@nx-example/shared-product-ui';
 
 @Component({
   selector: 'nx-example-product-detail-page',

--- a/libs/products/product-detail-page/src/lib/products-product-detail-page.module.ts
+++ b/libs/products/product-detail-page/src/lib/products-product-detail-page.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { SharedProductStateModule } from '@nx-example/shared/product/state';
+import { SharedProductStateModule } from '@nx-example/shared-product-state';
 
 import { ProductDetailPageComponent } from './product-detail-page/product-detail-page.component';
 

--- a/libs/products/product-detail-page/tsconfig.json
+++ b/libs/products/product-detail-page/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "lib": ["dom", "es2022"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/products/product-detail-page/tsconfig.lib.json
+++ b/libs/products/product-detail-page/tsconfig.lib.json
@@ -1,12 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "target": "es2015",
-    "declaration": true,
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"],
     "inlineSources": true,
-    "types": [],
-    "lib": ["dom", "es2022"]
+    "types": []
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
@@ -22,5 +24,18 @@
     "**/*.test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../shared/product/state/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/product/types/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/product/ui/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/products/product-detail-page/tsconfig.spec.json
+++ b/libs/products/product-detail-page/tsconfig.spec.json
@@ -1,13 +1,31 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "outDir": "out-tsc/spec",
     "module": "preserve",
-    "types": ["jest", "node"],
-    "target": "es2016",
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "target": "es2016",
+    "isolatedModules": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
+  ]
 }

--- a/libs/shared/assets/package.json
+++ b/libs/shared/assets/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-example/shared-assets",
+  "version": "0.0.0",
+  "private": true
+}

--- a/libs/shared/cart/state/.eslintrc.json
+++ b/libs/shared/cart/state/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/cart/state/package.json
+++ b/libs/shared/cart/state/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nx-example/shared-cart-state",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./react": {
+      "@nx-example/source": "./src/react.ts",
+      "types": "./src/react.ts",
+      "import": "./src/react.ts",
+      "default": "./src/react.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-product-data": "workspace:*",
+    "@nx-example/shared-product-state": "workspace:*"
+  }
+}

--- a/libs/shared/cart/state/src/lib/+state/cart.selectors.spec.ts
+++ b/libs/shared/cart/state/src/lib/+state/cart.selectors.spec.ts
@@ -1,5 +1,5 @@
-import { mockProducts } from '@nx-example/shared/product/data/testing';
-import { ProductsState } from '@nx-example/shared/product/state';
+import { mockProducts } from '@nx-example/shared-product-data/testing';
+import { ProductsState } from '@nx-example/shared-product-state';
 
 import { CartState } from './cart.reducer';
 import { getItemCost, getTotalCost } from './cart.selectors';

--- a/libs/shared/cart/state/src/lib/+state/cart.selectors.ts
+++ b/libs/shared/cart/state/src/lib/+state/cart.selectors.ts
@@ -1,7 +1,7 @@
 import {
   getProduct,
   ProductsState,
-} from '@nx-example/shared/product/state/react';
+} from '@nx-example/shared-product-state/react';
 import { CartItem, CartState } from './cart.reducer';
 
 // Lookup the 'Cart' feature state managed by NgRx

--- a/libs/shared/cart/state/tsconfig.json
+++ b/libs/shared/cart/state/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "lib": ["dom", "es2022"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/shared/cart/state/tsconfig.lib.json
+++ b/libs/shared/cart/state/tsconfig.lib.json
@@ -1,12 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
-    "target": "es2015",
-    "declaration": true,
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"],
     "inlineSources": true,
-    "types": [],
-    "lib": ["dom", "es2022"]
+    "types": []
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
@@ -22,5 +24,15 @@
     "**/*.test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../product/state/tsconfig.lib.json"
+    },
+    {
+      "path": "../../product/data/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/shared/cart/state/tsconfig.spec.json
+++ b/libs/shared/cart/state/tsconfig.spec.json
@@ -1,13 +1,31 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
+    "outDir": "out-tsc/spec",
     "module": "preserve",
-    "types": ["jest", "node"],
-    "target": "es2016",
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "target": "es2016",
+    "isolatedModules": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
+  ]
 }

--- a/libs/shared/e2e-utils/.eslintrc.json
+++ b/libs/shared/e2e-utils/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/e2e-utils/package.json
+++ b/libs/shared/e2e-utils/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@nx-example/shared-e2e-utils",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/libs/shared/e2e-utils/tsconfig.json
+++ b/libs/shared/e2e-utils/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["cypress"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    { "path": "./tsconfig.lib.json" }
   ]
 }

--- a/libs/shared/e2e-utils/tsconfig.lib.json
+++ b/libs/shared/e2e-utils/tsconfig.lib.json
@@ -1,9 +1,11 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "types": []
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "typeRoots": ["../../../node_modules/@types", "../../../node_modules"],
+    "types": ["cypress"]
   },
   "exclude": ["**/*.spec.ts"],
-  "include": ["**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/libs/shared/header/.eslintrc.json
+++ b/libs/shared/header/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/header/jest.config.ts
+++ b/libs/shared/header/jest.config.ts
@@ -1,7 +1,15 @@
 /* eslint-disable */
 module.exports = {
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          transform: { react: { runtime: 'automatic' } },
+        },
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/header',

--- a/libs/shared/header/package.json
+++ b/libs/shared/header/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@nx-example/shared-header",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-jsxify": "workspace:*"
+  }
+}

--- a/libs/shared/header/src/lib/header/header.element.ts
+++ b/libs/shared/header/src/lib/header/header.element.ts
@@ -1,4 +1,4 @@
-import { JSXify } from '@nx-example/shared/jsxify';
+import { JSXify } from '@nx-example/shared-jsxify';
 
 enum HeaderElementAttribute {
   Title = 'title',

--- a/libs/shared/header/tsconfig.json
+++ b/libs/shared/header/tsconfig.json
@@ -1,16 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/shared/header/tsconfig.lib.json
+++ b/libs/shared/header/tsconfig.lib.json
@@ -1,9 +1,17 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
     "types": []
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../jsxify/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/shared/header/tsconfig.spec.json
+++ b/libs/shared/header/tsconfig.spec.json
@@ -1,20 +1,26 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "outDir": "out-tsc/spec",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "**/*.spec.ts",
     "**/*.test.ts",
     "**/*.spec.tsx",
     "**/*.test.tsx",
-    "**/*.spec.js",
-    "**/*.test.js",
-    "**/*.spec.jsx",
-    "**/*.test.jsx",
     "**/*.d.ts",
     "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
   ]
 }

--- a/libs/shared/jsxify/.eslintrc.json
+++ b/libs/shared/jsxify/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/jsxify/package.json
+++ b/libs/shared/jsxify/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@nx-example/shared-jsxify",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/libs/shared/jsxify/tsconfig.json
+++ b/libs/shared/jsxify/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    { "path": "./tsconfig.lib.json" }
   ]
 }

--- a/libs/shared/jsxify/tsconfig.lib.json
+++ b/libs/shared/jsxify/tsconfig.lib.json
@@ -1,9 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
     "types": []
   },
   "exclude": ["**/*.spec.ts"],
-  "include": ["**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/libs/shared/product/data/.eslintrc.json
+++ b/libs/shared/product/data/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/product/data/package.json
+++ b/libs/shared/product/data/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nx-example/shared-product-data",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./testing": {
+      "@nx-example/source": "./src/testing.ts",
+      "types": "./src/testing.ts",
+      "import": "./src/testing.ts",
+      "default": "./src/testing.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-product-types": "workspace:*"
+  }
+}

--- a/libs/shared/product/data/src/lib/shared-product-data.ts
+++ b/libs/shared/product/data/src/lib/shared-product-data.ts
@@ -1,4 +1,4 @@
-import { Product } from '@nx-example/shared/product/types';
+import { Product } from '@nx-example/shared-product-types';
 
 export const products: Product[] = [
   {

--- a/libs/shared/product/data/tsconfig.json
+++ b/libs/shared/product/data/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    { "path": "./tsconfig.lib.json" }
   ]
 }

--- a/libs/shared/product/data/tsconfig.lib.json
+++ b/libs/shared/product/data/tsconfig.lib.json
@@ -1,9 +1,17 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
     "types": []
   },
   "exclude": ["**/*.spec.ts"],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../types/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/shared/product/state/.eslintrc.json
+++ b/libs/shared/product/state/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/product/state/package.json
+++ b/libs/shared/product/state/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nx-example/shared-product-state",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./react": {
+      "@nx-example/source": "./src/react.ts",
+      "types": "./src/react.ts",
+      "import": "./src/react.ts",
+      "default": "./src/react.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-product-data": "workspace:*",
+    "@nx-example/shared-product-types": "workspace:*"
+  }
+}

--- a/libs/shared/product/state/src/lib/+state/products.reducer.spec.ts
+++ b/libs/shared/product/state/src/lib/+state/products.reducer.spec.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { mockProducts } from '@nx-example/shared/product/data/testing';
+import { mockProducts } from '@nx-example/shared-product-data/testing';
 
 import { productsReducer, ProductsState } from './products.reducer';
 

--- a/libs/shared/product/state/src/lib/+state/products.reducer.ts
+++ b/libs/shared/product/state/src/lib/+state/products.reducer.ts
@@ -1,5 +1,5 @@
-import { products } from '@nx-example/shared/product/data';
-import { Product } from '@nx-example/shared/product/types';
+import { products } from '@nx-example/shared-product-data';
+import { Product } from '@nx-example/shared-product-types';
 
 import { ProductsAction } from './products.actions';
 

--- a/libs/shared/product/state/src/lib/+state/products.selectors.spec.ts
+++ b/libs/shared/product/state/src/lib/+state/products.selectors.spec.ts
@@ -1,4 +1,4 @@
-import { mockProducts } from '@nx-example/shared/product/data/testing';
+import { mockProducts } from '@nx-example/shared-product-data/testing';
 
 import { ProductsState } from './products.reducer';
 import { getProduct, getProducts } from './products.selectors';

--- a/libs/shared/product/state/tsconfig.json
+++ b/libs/shared/product/state/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "lib": ["dom", "es2022"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/shared/product/state/tsconfig.lib.json
+++ b/libs/shared/product/state/tsconfig.lib.json
@@ -1,12 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
-    "target": "es2015",
-    "declaration": true,
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"],
     "inlineSources": true,
-    "types": [],
-    "lib": ["dom", "es2022"]
+    "types": []
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
@@ -22,5 +24,15 @@
     "**/*.test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../types/tsconfig.lib.json"
+    },
+    {
+      "path": "../data/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/shared/product/state/tsconfig.spec.json
+++ b/libs/shared/product/state/tsconfig.spec.json
@@ -1,13 +1,31 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
+    "outDir": "out-tsc/spec",
     "module": "preserve",
-    "types": ["jest", "node"],
-    "target": "es2016",
     "moduleResolution": "bundler",
-    "isolatedModules": true
+    "target": "es2016",
+    "isolatedModules": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
+  ]
 }

--- a/libs/shared/product/types/.eslintrc.json
+++ b/libs/shared/product/types/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/product/types/package.json
+++ b/libs/shared/product/types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@nx-example/shared-product-types",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/libs/shared/product/types/tsconfig.json
+++ b/libs/shared/product/types/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    { "path": "./tsconfig.lib.json" }
   ]
 }

--- a/libs/shared/product/types/tsconfig.lib.json
+++ b/libs/shared/product/types/tsconfig.lib.json
@@ -1,9 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
     "types": []
   },
   "exclude": ["**/*.spec.ts"],
-  "include": ["**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/libs/shared/product/ui/.eslintrc.json
+++ b/libs/shared/product/ui/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "out-tsc"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/libs/shared/product/ui/jest.config.ts
+++ b/libs/shared/product/ui/jest.config.ts
@@ -1,7 +1,15 @@
 /* eslint-disable */
 module.exports = {
   transform: {
-    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]sx?$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          transform: { react: { runtime: 'automatic' } },
+        },
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   coverageDirectory: '../../../../coverage/libs/shared/product/ui',

--- a/libs/shared/product/ui/package.json
+++ b/libs/shared/product/ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@nx-example/shared-product-ui",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "@nx-example/source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "devDependencies": {
+    "@nx-example/shared-jsxify": "workspace:*"
+  }
+}

--- a/libs/shared/product/ui/src/lib/product-price/product-price.element.ts
+++ b/libs/shared/product/ui/src/lib/product-price/product-price.element.ts
@@ -1,4 +1,4 @@
-import { JSXify } from '@nx-example/shared/jsxify';
+import { JSXify } from '@nx-example/shared-jsxify';
 
 enum ProductPriceElementAttribute {
   Value = 'value',

--- a/libs/shared/product/ui/tsconfig.json
+++ b/libs/shared/product/ui/tsconfig.json
@@ -1,16 +1,9 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "types": ["node", "jest"]
-  },
-  "include": [],
   "files": [],
+  "include": [],
   "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
   ]
 }

--- a/libs/shared/product/ui/tsconfig.lib.json
+++ b/libs/shared/product/ui/tsconfig.lib.json
@@ -1,9 +1,17 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
+    "outDir": "out-tsc/lib",
+    "rootDir": "src",
     "types": []
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../jsxify/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/shared/product/ui/tsconfig.spec.json
+++ b/libs/shared/product/ui/tsconfig.spec.json
@@ -1,20 +1,26 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "outDir": "out-tsc/spec",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "**/*.spec.ts",
     "**/*.test.ts",
     "**/*.spec.tsx",
     "**/*.test.tsx",
-    "**/*.spec.js",
-    "**/*.test.js",
-    "**/*.spec.jsx",
-    "**/*.test.jsx",
     "**/*.d.ts",
     "jest.config.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "out-tsc"
   ]
 }

--- a/libs/shared/styles/package.json
+++ b/libs/shared/styles/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-example/shared-styles",
+  "version": "0.0.0",
+  "private": true
+}

--- a/nx.json
+++ b/nx.json
@@ -138,8 +138,23 @@
       "options": {
         "targetName": "test"
       }
+    },
+    {
+      "plugin": "@nx/js/typescript",
+      "options": {
+        "typecheck": { "targetName": "typecheck" },
+        "build": {
+          "targetName": "build",
+          "configName": "tsconfig.lib.json",
+          "buildDepsName": "build-deps",
+          "watchDepsName": "watch-deps"
+        }
+      }
     }
   ],
   "defaultBase": "master",
-  "analytics": true
+  "analytics": true,
+  "sync": {
+    "applyChanges": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "nx-example",
   "version": "0.0.0",
   "license": "MIT",
+  "workspaces": [
+    "apps/*",
+    "libs/*",
+    "libs/*/*",
+    "libs/*/*/*"
+  ],
   "scripts": {
     "start": "nx serve",
     "build": "nx build",
@@ -86,6 +92,7 @@
     "@swc/cli": "0.7.10",
     "@swc/core": "1.15.8",
     "@swc/helpers": "0.5.18",
+    "@swc/jest": "^0.2.39",
     "@testing-library/react": "15.0.6",
     "@types/jest": "30.0.0",
     "@types/node": "^18.16.9",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,11 +1,14 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "rootDir": ".",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "isolatedModules": true,
+    "customConditions": ["@nx-example/source"],
     "noUnusedLocals": true,
     "sourceMap": true,
-    "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
@@ -14,41 +17,7 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom"],
     "skipLibCheck": true,
-    "skipDefaultLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@nx-example/cart/cart-page": ["libs/cart/cart-page/src/index.ts"],
-      "@nx-example/products/home-page": [
-        "libs/products/home-page/src/index.ts"
-      ],
-      "@nx-example/products/product-detail-page": [
-        "libs/products/product-detail-page/src/index.ts"
-      ],
-      "@nx-example/shared/cart/state": ["libs/shared/cart/state/src/index.ts"],
-      "@nx-example/shared/cart/state/react": [
-        "libs/shared/cart/state/src/react.ts"
-      ],
-      "@nx-example/shared/e2e-utils": ["libs/shared/e2e-utils/src/index.ts"],
-      "@nx-example/shared/header": ["libs/shared/header/src/index.ts"],
-      "@nx-example/shared/jsxify": ["libs/shared/jsxify/src/index.ts"],
-      "@nx-example/shared/product/data": [
-        "libs/shared/product/data/src/index.ts"
-      ],
-      "@nx-example/shared/product/data/testing": [
-        "libs/shared/product/data/src/testing.ts"
-      ],
-      "@nx-example/shared/product/state": [
-        "libs/shared/product/state/src/index.ts"
-      ],
-      "@nx-example/shared/product/state/react": [
-        "libs/shared/product/state/src/react.ts"
-      ],
-      "@nx-example/shared/product/types": [
-        "libs/shared/product/types/src/index.ts"
-      ],
-      "@nx-example/shared/product/ui": ["libs/shared/product/ui/src/index.ts"],
-      "@nx-example/shared/styles": ["libs/shared/styles/src/index.ts"]
-    }
+    "skipDefaultLibCheck": true
   },
   "exclude": ["node_modules", "tmp"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,51 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    {
+      "path": "./apps/cart"
+    },
+    {
+      "path": "./apps/cart-e2e"
+    },
+    {
+      "path": "./apps/products"
+    },
+    {
+      "path": "./apps/products-e2e"
+    },
+    {
+      "path": "./libs/cart/cart-page"
+    },
+    {
+      "path": "./libs/products/home-page"
+    },
+    {
+      "path": "./libs/products/product-detail-page"
+    },
+    {
+      "path": "./libs/shared/cart/state"
+    },
+    {
+      "path": "./libs/shared/e2e-utils"
+    },
+    {
+      "path": "./libs/shared/header"
+    },
+    {
+      "path": "./libs/shared/jsxify"
+    },
+    {
+      "path": "./libs/shared/product/data"
+    },
+    {
+      "path": "./libs/shared/product/state"
+    },
+    {
+      "path": "./libs/shared/product/types"
+    },
+    {
+      "path": "./libs/shared/product/ui"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4292,6 +4292,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/create-cache-key-function@npm:^30.0.0":
+  version: 30.4.1
+  resolution: "@jest/create-cache-key-function@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+  checksum: 10c0/2cdf2479e020e022626da6543a95d2fbf7edccac7550c0e88dad13737b7fb5c97e172a0d62a9817c1ceca0fb5c24e220c28c6054a384d0101397ad3aa99174b2
+  languageName: node
+  linkType: hard
+
 "@jest/diff-sequences@npm:30.0.1":
   version: 30.0.1
   resolution: "@jest/diff-sequences@npm:30.0.1"
@@ -4500,6 +4509,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/pattern@npm:30.4.0":
+  version: 30.4.0
+  resolution: "@jest/pattern@npm:30.4.0"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.4.0"
+  checksum: 10c0/05bc0799f84f3750bbbff0f9a546979efd0dbcee86c1be98b9e2811a68885809ec7b5cca39b8dda1497cb7cf17b7be936019fba8dfbcd9c53b181e03e67f4f82
+  languageName: node
+  linkType: hard
+
 "@jest/reporters@npm:30.3.0":
   version: 30.3.0
   resolution: "@jest/reporters@npm:30.3.0"
@@ -4587,6 +4606,15 @@ __metadata:
   dependencies:
     "@sinclair/typebox": "npm:^0.34.0"
   checksum: 10c0/449dcd7ec5c6505e9ac3169d1143937e67044ae3e66a729ce4baf31812dfd30535f2b3b2934393c97cfdf5984ff581120e6b38f62b8560c8b5b7cc07f4175f65
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/schemas@npm:30.4.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/96f388ebfc1974457fcbde2ad36c40a0b549cba3f624fe8d9d6e5903a152dc75e4043f4ac9ac7668622f2ecb0f9a4dcb9a38edf3bc0d52b82045b2bb2b69b72a
   languageName: node
   linkType: hard
 
@@ -4769,6 +4797,21 @@ __metadata:
     "@types/yargs": "npm:^17.0.33"
     chalk: "npm:^4.1.2"
   checksum: 10c0/c3e3f4de0b77a7ced345f47d3687b1094c1b6c1521529a7ca66a76f9a80194f79179a1dbc32d6761a5b67914a8f78be1e65d1408107efcb1f252c4a63b5ddd92
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/types@npm:30.4.1"
+  dependencies:
+    "@jest/pattern": "npm:30.4.0"
+    "@jest/schemas": "npm:30.4.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/4c79f6dbdb1c7eaab5da255fc696c7cae744759d4020e42da8aa63b37fe55ce594be73075fe1ee5407dd59d7e47975be9f674bfc81e91bae2c89c62d27ba55a1
   languageName: node
   linkType: hard
 
@@ -6338,6 +6381,146 @@ __metadata:
   checksum: 10c0/227483417d1f36011d35d1b868cd7a9c615553f195a86a282ca3c273e89f38f172fc1fcbb8f1635d419c861679570887874a37f9f21350e0b6fc813930224358
   languageName: node
   linkType: hard
+
+"@nx-example/cart-cart-page@workspace:*, @nx-example/cart-cart-page@workspace:libs/cart/cart-page":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/cart-cart-page@workspace:libs/cart/cart-page"
+  dependencies:
+    "@nx-example/shared-cart-state": "workspace:*"
+    "@nx-example/shared-product-state": "workspace:*"
+    "@nx-example/shared-product-ui": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/cart-e2e@workspace:apps/cart-e2e":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/cart-e2e@workspace:apps/cart-e2e"
+  dependencies:
+    "@nx-example/shared-e2e-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/cart@workspace:apps/cart":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/cart@workspace:apps/cart"
+  dependencies:
+    "@nx-example/cart-cart-page": "workspace:*"
+    "@nx-example/shared-assets": "workspace:*"
+    "@nx-example/shared-header": "workspace:*"
+    "@nx-example/shared-styles": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/products-e2e@workspace:apps/products-e2e":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/products-e2e@workspace:apps/products-e2e"
+  dependencies:
+    "@nx-example/shared-e2e-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/products-home-page@workspace:*, @nx-example/products-home-page@workspace:libs/products/home-page":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/products-home-page@workspace:libs/products/home-page"
+  dependencies:
+    "@nx-example/shared-product-state": "workspace:*"
+    "@nx-example/shared-product-types": "workspace:*"
+    "@nx-example/shared-product-ui": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/products-product-detail-page@workspace:*, @nx-example/products-product-detail-page@workspace:libs/products/product-detail-page":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/products-product-detail-page@workspace:libs/products/product-detail-page"
+  dependencies:
+    "@nx-example/shared-product-state": "workspace:*"
+    "@nx-example/shared-product-ui": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/products@workspace:apps/products":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/products@workspace:apps/products"
+  dependencies:
+    "@nx-example/products-home-page": "workspace:*"
+    "@nx-example/products-product-detail-page": "workspace:*"
+    "@nx-example/shared-assets": "workspace:*"
+    "@nx-example/shared-header": "workspace:*"
+    "@nx-example/shared-styles": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-assets@workspace:*, @nx-example/shared-assets@workspace:libs/shared/assets":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-assets@workspace:libs/shared/assets"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-cart-state@workspace:*, @nx-example/shared-cart-state@workspace:libs/shared/cart/state":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-cart-state@workspace:libs/shared/cart/state"
+  dependencies:
+    "@nx-example/shared-product-data": "workspace:*"
+    "@nx-example/shared-product-state": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-e2e-utils@workspace:*, @nx-example/shared-e2e-utils@workspace:libs/shared/e2e-utils":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-e2e-utils@workspace:libs/shared/e2e-utils"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-header@workspace:*, @nx-example/shared-header@workspace:libs/shared/header":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-header@workspace:libs/shared/header"
+  dependencies:
+    "@nx-example/shared-jsxify": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-jsxify@workspace:*, @nx-example/shared-jsxify@workspace:libs/shared/jsxify":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-jsxify@workspace:libs/shared/jsxify"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-product-data@workspace:*, @nx-example/shared-product-data@workspace:libs/shared/product/data":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-product-data@workspace:libs/shared/product/data"
+  dependencies:
+    "@nx-example/shared-product-types": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-product-state@workspace:*, @nx-example/shared-product-state@workspace:libs/shared/product/state":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-product-state@workspace:libs/shared/product/state"
+  dependencies:
+    "@nx-example/shared-product-data": "workspace:*"
+    "@nx-example/shared-product-types": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-product-types@workspace:*, @nx-example/shared-product-types@workspace:libs/shared/product/types":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-product-types@workspace:libs/shared/product/types"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-product-ui@workspace:*, @nx-example/shared-product-ui@workspace:libs/shared/product/ui":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-product-ui@workspace:libs/shared/product/ui"
+  dependencies:
+    "@nx-example/shared-jsxify": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@nx-example/shared-styles@workspace:*, @nx-example/shared-styles@workspace:libs/shared/styles":
+  version: 0.0.0-use.local
+  resolution: "@nx-example/shared-styles@workspace:libs/shared/styles"
+  languageName: unknown
+  linkType: soft
 
 "@nx/angular@npm:23.0.0-beta.12":
   version: 23.0.0-beta.12
@@ -8530,6 +8713,19 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/fe1f33ebb968558c5a0c595e54f2e479e4609bff844f9ca9a2d1ffd8dd8504c26f862a11b031f48f75c95b0381c2966c3dd156e25942f90089badd24341e7dbb
+  languageName: node
+  linkType: hard
+
+"@swc/jest@npm:^0.2.39":
+  version: 0.2.39
+  resolution: "@swc/jest@npm:0.2.39"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^30.0.0"
+    "@swc/counter": "npm:^0.1.3"
+    jsonc-parser: "npm:^3.2.0"
+  peerDependencies:
+    "@swc/core": "*"
+  checksum: 10c0/2df5f215bb7a3f31e1db606e3ac01c4e67900e8db004b38dbfaa09f87bcc2b054070211086e095eddcd174ee561b696fcf679ea38263fa6daf69fee37dacbdc9
   languageName: node
   linkType: hard
 
@@ -17460,6 +17656,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:30.4.0":
+  version: 30.4.0
+  resolution: "jest-regex-util@npm:30.4.0"
+  checksum: 10c0/fe7426f67b54d38bed8e9d6e6a099d63d72f41f5bf65b922d9d03fedcb55c614b45657207632f6ee22d0a59d8d11327891f258d23f68a58912fcdb0f7db48435
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:30.3.0":
   version: 30.3.0
   resolution: "jest-resolve-dependencies@npm:30.3.0"
@@ -19897,6 +20100,7 @@ __metadata:
     "@swc/cli": "npm:0.7.10"
     "@swc/core": "npm:1.15.8"
     "@swc/helpers": "npm:0.5.18"
+    "@swc/jest": "npm:^0.2.39"
     "@testing-library/react": "npm:15.0.6"
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:^18.16.9"


### PR DESCRIPTION
## Summary

Migrates the workspace from Nx integrated style (tsconfig path aliases) to TypeScript solution-style — package manager workspaces + project references.

- Each project now has a `package.json` with an `exports` map (`@nx-example/source` + `default` conditions) and `workspace:*` dependencies; `tsconfig.base.json` drops `paths` in favour of `moduleResolution: bundler` + `customConditions`.
- Adds a root `tsconfig.json` referencing all projects and registers the `@nx/js/typescript` inferred plugin.
- **Angular `products` app** moved to the esbuild builders (`@nx/angular:application`, `@angular/build:dev-server`). The legacy `@angular-devkit/build-angular:browser` builder cannot compile lazy-loaded library *source* resolved through workspace packages — it silently emitted empty lazy chunks, producing a blank page.
- **Jest**: the four non-Angular projects (`cart`, `cart-page`, `header`, `product-ui`) switched to `@swc/jest`. ts-jest forces `module: commonjs`, which conflicts with `moduleResolution: bundler` + `customConditions`. SWC transpiles per-file and lets the Nx jest resolver handle resolution. Angular projects stay on `jest-preset-angular`.

## Test plan

`nx run-many -t typecheck build lint test e2e --skip-nx-cache` — all 15 projects green, including both Cypress e2e suites.