### PR TITLE
test: reproduce v4 worker nx module resolution failure (do not merge)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ jobs:
   main:
     docker:
       - image: cimg/node:lts-browsers
+    environment:
+      # TEMPORARY: reproducing the v4 worker's bare `require('nx/...')` failing
+      # when nx 23.2 moves the Cloud bundle to ~/.nx/<workspaceId>/cache/cloud.
+      NX_CLOUD_CONTINUOUS_ASSIGNMENT: 'true'
+      NX_VERBOSE_LOGGING: 'true'
     steps:
       - checkout
 

--- a/libs/shared/product/data/src/index.ts
+++ b/libs/shared/product/data/src/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/shared-product-data';
+
+// Touched to make `nx affected` non-empty for the v4 worker repro (temporary).


### PR DESCRIPTION
> **Do not merge.** Temporary branch to reproduce a Nx Cloud agent failure. Delete once we have the answer.

## What this tests

nx 23.2 moved the cache to `~/.nx/<workspaceId>/cache`, which moves the Nx Cloud client bundle
outside the workspace. The v4 distributed task worker loads four nx modules with a bare
`require('nx/...')`:

- `nx/src/utils/workspace-context`
- `nx/src/project-graph/build-project-graph`
- `nx/src/project-graph/error-types`
- `nx/src/project-graph/utils/build-all-workspace-files`

A bare `require` resolves from the bundle's own directory, so once the bundle leaves the
workspace those lookups fail and `hydrateNxFileMapForHasher` rethrows, terminating the agent.

`nx` and `ocean` do not hit this because pnpm writes `node_modules/.bin/nx-cloud` as a shell shim
that exports `NODE_PATH`, giving Node a `globalPaths` fallback. This repo uses yarn 4 with
`nodeLinker: node-modules`, which writes a plain symlink and sets no `NODE_PATH` — so it should
fail where the pnpm repos do not.

## The change

Enables the V4 path (the only missing precondition here — this repo is already on 23.2.0-rc.2 with
Nx Agents) plus verbose logging so the agent prints its bundle path.

## Expected result

Agents fail with:

```
[Nx Cloud V4 worker fatal] Cannot find module 'nx/src/utils/workspace-context'
Require stack:
- /home/workflows/.nx/<hash>/cache/cloud/<version>/lib/core/runners/distributed-agent/v4/discrete-task-worker.js
```

Fix is in nrwl/ocean#13552, which routes those four through `lightClientRequire`.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gentle-falconet-3ea001b7">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->